### PR TITLE
Fix Dockerfile and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:latest
-COPY . /app
+FROM golang:latest as build
 WORKDIR /app
-RUN go mod tidy
-RUN make build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . ./
+RUN CGO_ENABLED=0 go build -v ./cmd/apiserver
+
 FROM alpine
-COPY --from=0 /app/apiserver .
+COPY --from=build /app/apiserver /app/.dev.env ./
 CMD ["./apiserver"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - POSTGRES_DB=postgres
+      - POSTGRES_DB=spotify-clone
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
     networks:
@@ -15,7 +15,8 @@ services:
     volumes:
       - database_postgres:/var/lib/postgresql/data
   web:
-    build: .
+    restart: always
+    build: ./
     container_name: "spotify-clone-server"
     environment:
       PORT: "5000"
@@ -32,8 +33,8 @@ services:
       - fullstack
 
 volumes:
-  database_postgres:
+  database_postgres: null
 
 networks:
- fullstack:
-  driver: bridge
+  fullstack:
+    driver: bridge


### PR DESCRIPTION
Dockerfile could not build an image with an error "exec user process
caused: no such file or directory". The problems were that .dev.env
file was not copied in the second stage and that compilation did not
have CGO_ENABLED=0, which disables glibc dependency. Alpine that is
used for the second stage does not use glibc, it uses musl-libc instead.
The problem in docker-compose was that the name of the database 
was different from the name that the server tried to connect.